### PR TITLE
--boot Argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ macOS Sierra introduced a new mechanism for both application and system level lo
 Thus we can no longer get system.log from /var/log/system.log.
 Which made developer's debugging life further from innocence.
 That's why I started this project to just simply log all of system.log to console.
-More functions will be added later, if you have good idea for this project, don't hesitate to make a pull request for me :)
+More functionality will be added later, if you have a good idea for this project, don't hesitate to make a pull request for me :)
 
 I wait for you. Wish you all enjoy this tiny but useful program.
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 Get system log from macOS(10.12+) much easier
 ============
 
-Well as the arrival of macOS Sierra, we can no more get system.log from
-/var/log/system.log. Which made developers' life innocence for further
-debugging. That's why I start this project to just simply log all the system.log
-to console. More functions will be added later, if you have good idea for this project,
-don't hesitate to pull issue for me :)
+macOS Sierra introduced a new mechanism for both application and system level logging.
+Thus we can no longer get system.log from /var/log/system.log.
+Which made developer's debugging life further from innocence.
+That's why I started this project to just simply log all of system.log to console.
+More functions will be added later, if you have good idea for this project, don't hesitate to make a pull request for me :)
 
 I wait for you. Wish you all enjoy this tiny but useful program.
 
 How to use maclog?
 ----------------
-- Download binary exectuable program [here] (https://github.com/syscl/maclog/files/692460/maclog-v1.2.zip)
-- Double left click to execute it(Note: for first time launch: ```Right Click``` ▶ ```Open```)
+- Download binary executable program [here](https://github.com/syscl/maclog/files/692460/maclog-v1.2.zip).
+- Double left click to execute it (Note: for first time launch: ```Right Click ▶ Open```)
 
 If you want to compile it, following the below step:
 - Download the latest source code by entering the following command in a terminal window:
@@ -25,10 +25,23 @@ cd maclog
 clang maclog.m -fobjc-arc -fmodules -mmacosx-version-min=10.6 -o maclog
 ```
 
+Arguments
+---------
+maclog default behaviour is to log all messages of the current day.
+
+The following arguments are accepted:
+- `--boot`: Change default behaviour to only show log messages since last boot time.
+
 # Change Log
+2017-6-20
+
+- Added `--boot` option
+- Added `char *gCurTime(void)`
+- Removed some unneeded headers
+
 2017-1-8
 
-- Release v1.2 binary exectuable program credit @schdt899 @smolderas @BreBo
+- Release v1.2 binary executable program credit @schdt899 @smolderas @BreBo
 - Add *gCurTime(void)
 - Remove strdup(char *)
 - Optimize code 

--- a/maclog.h
+++ b/maclog.h
@@ -15,8 +15,12 @@
 //
 // for open(...)
 //
-#include <sys/stat.h>
 #include <fcntl.h>
+#include <sys/stat.h>
+//
+// for sysctl(...)
+//
+#include <sys/sysctl.h>
 //
 // for time
 //

--- a/maclog.m
+++ b/maclog.m
@@ -29,6 +29,9 @@ char *gCurTime(void)
     return gTime;
 }
 
+//
+// Modified from https://stackoverflow.com/questions/3269321/osx-programmatically-get-uptime#answer-11676260
+//
 char *gBootTime(void)
 {
     struct timeval gBootTime;

--- a/maclog.m
+++ b/maclog.m
@@ -9,11 +9,6 @@
 // 4.0 Unported License => http://creativecommons.org/licenses/by-nc/4.0
 //
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <sys/types.h>
-#include <unistd.h>
-
 //
 // syscl::header files
 //
@@ -24,7 +19,36 @@ char *gCurTime(void)
     char *gTime = calloc(11, sizeof(char));
     time_t gRawTime = time(NULL);
     struct tm *gTimeInf = localtime(&gRawTime);
-    sprintf(gTime, "%d-%d-%d",gTimeInf->tm_year + 1900, gTimeInf->tm_mon + 1, gTimeInf->tm_mday);
+    sprintf(
+        gTime,
+        "%d-%d-%d",
+        gTimeInf->tm_year + 1900,
+        gTimeInf->tm_mon + 1,
+        gTimeInf->tm_mday
+    );
+    return gTime;
+}
+
+char *gBootTime(void)
+{
+    struct timeval gBootTime;
+
+    size_t len = sizeof(gBootTime);
+    int mib[2] = {CTL_KERN, KERN_BOOTTIME};
+    if(sysctl(mib, 2, &gBootTime, &len, NULL, 0) < 0) return gCurTime();
+
+    char *gTime = calloc(20, sizeof(char));
+    struct tm *gTimeInf = localtime(&gBootTime.tv_sec);
+    sprintf(
+        gTime,
+        "%d-%d-%d %d:%d:%d",
+        gTimeInf->tm_year + 1900,
+        gTimeInf->tm_mon + 1,
+        gTimeInf->tm_mday,
+        gTimeInf->tm_hour,
+        gTimeInf->tm_min,
+        gTimeInf->tm_sec
+    );
     return gTime;
 }
 
@@ -42,7 +66,11 @@ int main(int argc, char **argv)
             close(STDOUT_FILENO);
             dup2(fd, STDOUT_FILENO);
         }
-        gLogArgs[9] = gCurTime();
+
+        gLogArgs[9] = argc > 1 && (strcmp(argv[1], "--boot") == 0)
+            ? gBootTime()
+            : gCurTime();
+
         //
         // log system log now
         //
@@ -68,6 +96,6 @@ int main(int argc, char **argv)
         printf("Fork failed\n");
         return EXIT_FAILURE;
     }
-    
+
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Hi,
I added a new command line argument `--boot` to maclog, to make it easier to only see the messages logged after the last boot time.
I know close to nothing of Objective-C, so I coded this as if it was C. In case I made any mistake let me know.
p.s: I also made some changes to README for clarification and to fix some typos.